### PR TITLE
Fixes #34243 - Tags input is expected as a string

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -88,7 +88,7 @@ if defined? ForemanRemoteExecution
             :children => [
               {
                 :name => :tags,
-                :type => Array,
+                :type => String,
                 :opts => { :required => false, :desc => N_('A comma separated list of tags to use for Ansible run') }
               },
               {


### PR DESCRIPTION
Fixes the issue when provided tags are stored in an array that is saved as a string. It could be achieved differently as well, and we could accept Arrays and Strings by changing InvocationProviderInputValue model. I decided to go this way, as Ansible accepts strings only as tags. So, it should look like that:
`ansible-playbook example.yml --tags "configuration,packages"`

https://community.theforeman.org/t/hammer-job-invocation-tags-have-wrong-formatting/26797
https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html